### PR TITLE
If types are same, then no diagnostic.

### DIFF
--- a/NumberSuffix/NumberSuffix.Test/NumberSuffixUnitTests.vb
+++ b/NumberSuffix/NumberSuffix.Test/NumberSuffixUnitTests.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
 Namespace NumberSuffix.Test
+
   <TestClass>
   Public Class UnitTest
     Inherits CodeFixVerifier
@@ -43,6 +44,33 @@ Module Module1
   Function m(m2 As ULong, mask As ULong) As Boolean
     Dim fraction As ULong = m2 And mask
     Return fraction <> 0UL
+  End Function
+End Module"
+      VerifyBasicFix(test, fixtest)
+    End Sub
+
+    <TestMethod>
+    Public Sub TestMethod3()
+
+      Dim test = "
+Module Module1
+  Function m() As Integer
+    Dim fraction As Integer = 1
+    Return fraction + 1
+  End Function
+End Module"
+      Dim expected = New DiagnosticResult With {.Id = "NumberSuffix",
+          .Message = String.Format("Do you want to add the type suffix '{0}'?", "UL"),
+          .Severity = DiagnosticSeverity.Warning}
+
+
+      VerifyBasicDiagnostic(test, expected)
+
+      Dim fixtest = "
+Module Module1
+  Function m() As Integer
+    Dim fraction As Integer = 1
+    Return fraction + 1
   End Function
 End Module"
       VerifyBasicFix(test, fixtest)

--- a/NumberSuffix/NumberSuffix/NumberSuffixAnalyzer.vb
+++ b/NumberSuffix/NumberSuffix/NumberSuffixAnalyzer.vb
@@ -40,10 +40,10 @@ Public Class NumberSuffixAnalyzer
     Dim nme = TryCast( context.Node, LiteralExpressionSyntax)
     If nme Is Nothing Then Exit Sub
     If nme.Kind <> SyntaxKind.NumericLiteralExpression Then Exit Sub
-    Dim si = context.SemanticModel.GetTypeInfo(nme, context.CancellationToken )
-    if si.ConvertedType.GetType.Equals(si.Type) Then exit Sub
     Dim tkn =nme.Token
     If HasTypeSuffix(tkn) Then Return
+    Dim si = context.SemanticModel.GetTypeInfo(nme, context.CancellationToken )
+    if si.ConvertedType.GetType.Equals(si.Type) Then exit Sub
     Dim p = nme.Parent
     If p Is Nothing Then exit Sub
     dim pe = TryCast(p, BinaryExpressionSyntax)
@@ -56,6 +56,7 @@ Public Class NumberSuffixAnalyzer
     Else
       return
     End If
+    If ct.Type.Equals(si.Type) THen Exit sub
     ' For all such symbols, produce a diagnostic.
     Dim ts = GetTypeSuffix( ct.Type)
     If ts Is Nothing Then Exit Sub
@@ -69,7 +70,7 @@ Public Class NumberSuffixAnalyzer
            txt.EndsWith("US") OrElse txt.EndsWith("UI") OrElse txt.EndsWith("UL")
   End Function
   Friend shared Function GetTypeSuffix(si AS ITypeSymbol) As String
-    dim tname=si.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+    dim tname=si.ToDisplayString(SymbolDisplayFormat.VisualBasicErrorMessageFormat)
     Select Case tname
            Case "Short"    : Return "S"
            Case "Integer"  : Return "I"


### PR DESCRIPTION
Reorder a check to make it earlier.
Check to see if left and right are same type.